### PR TITLE
Fixed buggy chain assignment algorithm in grand

### DIFF
--- a/grand/utils.py
+++ b/grand/utils.py
@@ -156,9 +156,9 @@ def add_ghosts(topology, positions, ff='tip3p', n=10, pdb='gcmc-extra-wats.pdb')
         modeller.add(addTopology=water.topology, addPositions=new_positions)
         ghosts.append(modeller.topology._numResidues - 1)
 
-    # Fine a chain letter for the ghost chain.
+    # Find a chain letter for the ghost chain.
     # Need to be careful here as openmm.app.modeller.addSolvent can add water
-    # chains with two characters in, so the original algorithm to icrement the
+    # chains with two characters in, so the original algorithm to increment the
     # chain letter for the last atom fails (e.g. on chain '10').
     # If none found, assign to chain '_'
     new_chain='_'


### PR DESCRIPTION
If you start with a protein with 9 chains, openmm.app.Modeller.add_solvent adds the solvent as chain '10'. The two-character chain name broke the code for determining what chain the ghost waters should be in. New code finds the first unused chain letter and uses that, or chain '_' if no other can be found.

(SFT-23979)